### PR TITLE
Feature/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,44 @@ You can use `pip` or [uv](https://docs.astral.sh/uv/). From the pycht root folde
 
 You're ready to hack!
 
+## 🧰 Command-Line Interface (CLI)
+
+You can use `pycht` as a command-line tool to generate stencil layers from an image — perfect for street art, posters, or digital illustration.
+
+### 🖥️ Installation
+
+Install in editable mode (dev mode) with [uv](https://github.com/astral-sh/uv) or pip:
+
+```bash
+uv pip install -e .
+```
+
+Make sure you have the required dependencies listed in `pyproject.toml`.
+
+---
+
+### 🚀 Usage
+
+```bash
+pycht stencil <input-img> [OPTIONS]
+```
+
+**Arguments:**
+- `<input-img>`: Path to the input image (JPEG, PNG, etc.)
+
+**Options:**
+- `--output-path TEXT` – Directory where output layers will be saved (default: `./output`)
+- `--nb-colors INTEGER` – Number of stencil layers to generate (default: `3`)
+
+---
+
+### ✅ Example
+
+```bash
+pycht stencil misc/cat.jpg --nb-colors 4 --output-path .
+```
+
+This will create 4 stencil layers and save them in the current folder.
 
 ## 🖖 Contributing
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ uv pip install -e .
 
 Make sure you have the required dependencies listed in `pyproject.toml`.
 
----
-
 ### 🚀 Usage
 
 ```bash
@@ -140,8 +138,6 @@ pycht stencil <input-img> [OPTIONS]
 **Options:**
 - `--output-path TEXT` – Directory where output layers will be saved (default: `./output`)
 - `--nb-colors INTEGER` – Number of stencil layers to generate (default: `3`)
-
----
 
 ### ✅ Example
 

--- a/notebook/pycht.ipynb
+++ b/notebook/pycht.ipynb
@@ -7,17 +7,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"..\")\n",
+    "\n",
     "from pycht import Pycht"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "3829209b-33d0-4ca9-8ea2-25238a54955f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "Pycht().stencil('../misc/cat.jpg', 'stencil_cat.jpg', 4)"
+    "Pycht().stencil('../misc/cat.jpg', 4)"
    ]
   },
   {
@@ -45,7 +49,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/pycht/__init__.py
+++ b/pycht/__init__.py
@@ -5,5 +5,6 @@ Package building.
 from .pycht import Pycht
 from .image_processing import ImageProcessing
 from .clustering import Clustering
+from .cli import stencil
 
-__all__ = ["Pycht", "ImageProcessing", "Clustering"]
+__all__ = ["Pycht", "ImageProcessing", "Clustering", "stencil"]

--- a/pycht/cli.py
+++ b/pycht/cli.py
@@ -3,15 +3,20 @@ Main project settings and execution logic.
 """
 
 import typer
+from typing_extensions import Annotated
 
 from .pycht import Pycht
 
-
-app = typer.Typer()
+app = typer.Typer(help="Main CLI for Pycht.")
 
 
 @app.command()
-def stencil(input_img: str, nb_colors: int = 4, output_path: str = "./"):
+def stencil(
+    input_img: Annotated[str, typer.Argument(help="The input image")],
+    nb_colors: Annotated[int, typer.Argument(help="Number of color clusters")] = 3,
+    output_path: Annotated[str, typer.Argument(help="The output folder")] = "./",
+):
+    """Stencil your picture with an input image 🎨 !"""
     typer.echo(f"Processing {input_img} into {output_path} with {nb_colors} levels.")
     Pycht().stencil(input_img, nb_colors, output_path)
 

--- a/pycht/cli.py
+++ b/pycht/cli.py
@@ -1,0 +1,20 @@
+"""
+Main project settings and execution logic.
+"""
+
+import typer
+
+from .pycht import Pycht
+
+
+app = typer.Typer()
+
+
+@app.command()
+def stencil(input_img: str, nb_colors: int = 4, output_path: str = "./"):
+    typer.echo(f"Processing {input_img} into {output_path} with {nb_colors} levels.")
+    Pycht().stencil(input_img, nb_colors, output_path)
+
+
+if __name__ == "__main__":
+    app()

--- a/pycht/image_processing.py
+++ b/pycht/image_processing.py
@@ -115,9 +115,7 @@ class ImageProcessing:
         # separate differants colors
         df = pd.DataFrame(res)
         df.columns = ["col1", "col2", "col3"]
-        df["tot"] = (
-            df["col1"].astype(str) + df["col2"].astype(str) + df["col3"].astype(str)
-        )
+        df["tot"] = df["col1"].astype(str) + df["col2"].astype(str) + df["col3"].astype(str)
         df["tot"].unique()
         cmp = 1
         for i in df["tot"].unique():

--- a/pycht/pycht.py
+++ b/pycht/pycht.py
@@ -18,7 +18,7 @@ class Pycht:
         self.image_processing = ImageProcessing()
         self.clustering = Clustering()
 
-    def stencil(self, input_img: str, nb_colors: int = 4, output_path: str = "./") -> None:
+    def stencil(self, input_img: str, nb_colors: int = 3, output_path: str = "./") -> None:
         """
         Generate color stencils from an input image using K-Means clustering.
 

--- a/pycht/pycht.py
+++ b/pycht/pycht.py
@@ -18,7 +18,7 @@ class Pycht:
         self.image_processing = ImageProcessing()
         self.clustering = Clustering()
 
-    def stencil(self, input_img: str, nb_colors: int=4, output_path: str="./") -> None:
+    def stencil(self, input_img: str, nb_colors: int = 4, output_path: str = "./") -> None:
         """
         Generate color stencils from an input image using K-Means clustering.
 
@@ -35,9 +35,7 @@ class Pycht:
             Number of color clusters to segment the image into.
         """
         return self.image_processing.color_separation(
-            self.clustering.compute(
-                self.image_processing.process(input_img), nb_colors
-            ),
+            self.clustering.compute(self.image_processing.process(input_img), nb_colors),
             input_img,
             output_path,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
     "mkdocs-material>=9.6.9",
     "mkdocstrings[python]>=0.29.0",
     "pylint>=3.3.6",
+    "typer>=0.15.2",
 ]
 
 [build-system]
@@ -30,6 +31,9 @@ exclude = ["tests*", "notebook*", "misc*"]
 
 [tool.uv]
 required-version = ">=0.6.11,<0.7"
+
+[project.scripts]
+pycht = "pycht.cli:app"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Describe your changes

@garaud suggested in #46 that it would like to use pycht from the command-line such as:

```bash
$ pycht --n-colors 4 --output ./output-folder input.jpg
```

Add an entry point to the pyproject.toml in order to have the pycth command available when you install the package. A new cli.py module with a main function using argparse in order to call the pycth main function


## Issue ticket number and link

#46 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.