### PR TITLE
Feature/module structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Take a nice picture :
 
 Generate a 5 colors stencil model :
 ```python
->>> from pycht import Pycht
+>>> import pycht
 
->>> Pycht().stencil('cat.jpg', 5)
+>>> pycht.stencil('cat.jpg', 5)
 ```
 
  |                                    Stencil 1                                    |                                    stencil 2                                    |                                    stencil 3                                    |                                    stencil 4                                    |                                    stencil 5                                    |
@@ -101,7 +101,7 @@ Ready to turn your cat photo into street art? Let `pycht` paint it.
 
 ## 🧑‍💻 Development
 
-You can use `pip` or [uv](https://docs.astral.sh/uv/). From the pycht root folder, do:
+You can use `pip` or [uv](https://docs.astral.sh/uv/). From the `pycht` root folder, do:
 
 * `uv venv --python /path/to/3.12.x/python`. *Tips*: you can use [pyenv](https://github.com/pyenv/pyenv) to manage and
   install multiple Python versions. You can find a specific version at `~/.pyenv/versions/3.12.2/bin/python` for
@@ -129,7 +129,7 @@ Make sure you have the required dependencies listed in `pyproject.toml`.
 ### 🚀 Usage
 
 ```bash
-pycht stencil <input-img> [OPTIONS]
+pycht <input-img> [OPTIONS]
 ```
 
 **Arguments:**
@@ -142,7 +142,7 @@ pycht stencil <input-img> [OPTIONS]
 ### ✅ Example
 
 ```bash
-pycht stencil misc/cat.jpg --nb-colors 4 --output-path .
+pycht misc/cat.jpg --nb-colors 4 --output-path .
 ```
 
 This will create 4 stencil layers and save them in the current folder.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,10 +37,9 @@ uv sync --inexact
 Here’s how to process an image and create stencils:
 
 ```python
-from pycht import Pycht
+import Pycht
 
-p = Pycht()
-p.stencil("images/input.jpg", nb_colors=4, output_path="output/")
+pycht.stencil("images/input.jpg", nb_colors=4, output_path="output/")
 ```
 
 This will:

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,11 +28,10 @@ It automatically reduces an image’s color palette into distinct clusters and g
 ## 📦 Example Usage
 
 ```python
-from pycht import Pycht
+import pycht
 
 # Create a stencil with 5 color clusters
-p = Pycht()
-p.stencil("images/input.jpg", nb_colors=5)
+pycht.stencil("images/input.jpg", nb_colors=5)
 ```
 
 This will generate:
@@ -56,7 +55,7 @@ Want to experiment? Just provide any image and see how it gets broken down into 
 
 ## 🛠️ Technologies Used
 
-- Python 3.10+
+- Python 3.12+
 - OpenCV
 - NumPy
 - Pandas

--- a/notebook/pycht.ipynb
+++ b/notebook/pycht.ipynb
@@ -9,19 +9,27 @@
    "source": [
     "import sys\n",
     "\n",
-    "sys.path.append(\"..\")\n",
-    "\n",
-    "from pycht import Pycht"
+    "sys.path.append(\"..\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "05d69918",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pycht"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "3829209b-33d0-4ca9-8ea2-25238a54955f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "Pycht().stencil('../misc/cat.jpg', 4)"
+    "pycht.stencil('../misc/cat.jpg', 4)"
    ]
   },
   {

--- a/pycht/__init__.py
+++ b/pycht/__init__.py
@@ -5,6 +5,10 @@ Package building.
 from .pycht import Pycht
 from .image_processing import ImageProcessing
 from .clustering import Clustering
-from .cli import stencil
+from .cli import compute
 
-__all__ = ["Pycht", "ImageProcessing", "Clustering", "stencil"]
+__all__ = ["Pycht", "ImageProcessing", "Clustering", "compute"]
+
+
+def stencil(input_img: str, nb_colors: int = 3, output_path: str = "."):
+    return Pycht().stencil(input_img, nb_colors, output_path)

--- a/pycht/cli.py
+++ b/pycht/cli.py
@@ -11,14 +11,25 @@ app = typer.Typer(help="Main CLI for Pycht.")
 
 
 @app.command()
-def stencil(
+def compute(
     input_img: Annotated[str, typer.Argument(help="The input image")],
-    nb_colors: Annotated[int, typer.Argument(help="Number of color clusters")] = 3,
-    output_path: Annotated[str, typer.Argument(help="The output folder")] = "./",
+    nb_colors: Annotated[int, typer.Option("--nb-colors", "-n", help="Number of color clusters")] = 3,
+    output_path: Annotated[str, typer.Option("--output-path", "-o", help="The output folder")] = "./",
 ):
     """Stencil your picture with an input image 🎨 !"""
     typer.echo(f"Processing {input_img} into {output_path} with {nb_colors} levels.")
     Pycht().stencil(input_img, nb_colors, output_path)
+
+
+# @app.command()
+# def compute(
+#     input_img: Annotated[str, typer.Argument(help="The input image")],
+#     nb_colors: Annotated[int, typer.Option("--nb-colors", "-n", help="Number of color clusters")] = 3,
+#     output_path: Annotated[str, typer.Option("--output-path", "-o", help="The output folder")] = "./",
+# ):
+#     """Stencil your picture with an input image 🎨 !"""
+#     typer.echo(f"Processing {input_img} into {output_path} with {nb_colors} levels.")
+#     Pycht().stencil(input_img, nb_colors, output_path)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ requires-python = ">=3.12"
 dependencies = [
     "opencv-python>=4.11.0.86",
     "pandas>=2.2.3",
+    "typer",
+    "typing-extensions"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Describe your changes

Inspired by Pandas, from `pycht` call :

```python
from pycht import Pycht

Pycht().stencil(...)
```

To

```python
import pycht

pycht.stencil(...)
```

Also, as we had only one CLI function, `pycht stencil --option` is become by default `pycht --option` as it is a typer default behavior. 

## Issue ticket number and link

#25 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.